### PR TITLE
add format (regex validation) feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Validators:
 - [X] length 
 - [X] type 
 - [X] numericality (greater than, equal to, is integer, etc)
-- [ ] format - regex
+- [X] format - regex
 - [X] date - earliest, latest
 - [ ] common formats - url, email, etc
 - [ ] enums/lists - validate if value exists in the given list

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/herbsjs/suma/master/docs/logo.png" height="220"></p>
+ <p align="center"><img src="https://raw.githubusercontent.com/herbsjs/suma/master/docs/logo.png" height="220"></p> 
 
 # Suma
 
@@ -167,6 +167,21 @@ const result = validate(value, validations)
         { tooEarly: '2001-01-03T00:00:00.000Z') },
         { notAt: '2001-02-02T00:00:00.000Z') }
     ]
+} */
+```
+
+#### Format
+
+`format` (regex) -The format validator will validate a value against a regular expression of your chosing.
+
+```javascript
+const pattern = /^[0-9]{8}$/ // or you can use new RegExp('^[0-9]{8}$')
+const value = ''
+const validations = { format: pattern }
+const result = validate(value, validations) 
+/* {
+    value: '',
+    errors: [{ invalidFormat: true }]
 } */
 ```
 

--- a/README.md
+++ b/README.md
@@ -176,11 +176,11 @@ const result = validate(value, validations)
 
 ```javascript
 const pattern = /^[0-9]{8}$/ // or you can use new RegExp('^[0-9]{8}$')
-const value = ''
+const value = '05547-022'
 const validations = { format: pattern }
 const result = validate(value, validations) 
 /* {
-    value: '',
+    value: '05547-022',
     errors: [{ invalidFormat: true }]
 } */
 ```
@@ -248,7 +248,7 @@ const result = validate(value, validations)
 
 ### Null Values
 
-The `type`, `length`, `numericality` and `datetime` validators won't validate a value if it's `null` or `undefined`.
+The `type`, `length`, `numericality`, `format` and `datetime` validators won't validate a value if it's `null` or `undefined`.
 
 To ensure your your value is not null, use `allowNull: false` or `presence: true`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "suma",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/checker.js
+++ b/src/checker.js
@@ -69,6 +69,10 @@ class Checker {
         return false
     }
 
+    static isValidFormat(value,expression) {
+        return expression.test(value)
+    }
+    
     static isTooShort(value, minimum) {
         if (!this.isNumber(minimum)) throw Error(`Invalid minimum length. It must be a number.`)
         const length = value.length

--- a/src/errorCodes.js
+++ b/src/errorCodes.js
@@ -15,7 +15,8 @@ const codes = {
     tooEarly: 'tooEarly',
     tooLate: 'tooLate',
     notAt: 'notAt',
-    notADate: 'notADate'
+    notADate: 'notADate',
+    invalidFormat: 'invalidFormat'
 }
 
 module.exports = codes

--- a/src/suma.js
+++ b/src/suma.js
@@ -1,5 +1,6 @@
 const validators = {
     presence: require('./validators/presence'),
+    format: require('./validators/format'),
     allowNull: require('./validators/allowNull'),
     type: require('./validators/type'),
     length: require('./validators/length'),

--- a/src/validators/format.js
+++ b/src/validators/format.js
@@ -1,0 +1,20 @@
+const checker = require("../checker");
+const err = require("../errorCodes");
+
+function format(value, expression) {
+  let results = null
+  if (checker.isEmpty(value)) {
+    return null;
+  }
+
+  const result = expression.test(value);
+  if (result === false || !checker.isString(value))
+  {
+      results = results || []
+      results.push({ [err.invalidFormat]: true })
+  }
+
+  return results;
+}
+
+module.exports = format;

--- a/src/validators/format.js
+++ b/src/validators/format.js
@@ -2,19 +2,9 @@ const checker = require("../checker");
 const err = require("../errorCodes");
 
 function format(value, expression) {
-  let results = null
-  if (checker.isEmpty(value)) {
-    return null;
-  }
-
-  const result = expression.test(value);
-  if (result === false || !checker.isString(value))
-  {
-      results = results || []
-      results.push({ [err.invalidFormat]: true })
-  }
-
-  return results;
+  if (checker.isEmpty(value)) return null
+  const result = checker.isValidFormat(value,expression)
+  return result ? null: { [err.invalidFormat]: true }
 }
 
 module.exports = format;

--- a/test/validators/format.js
+++ b/test/validators/format.js
@@ -32,7 +32,7 @@ describe("format validation", () => {
        var pattern = /^[0-9]{8}$/
         
        const samples = [
-          "05541030",37130000
+          "05541030",37130000,['37130000']
        ]
 
        for (const value of samples) {
@@ -67,34 +67,14 @@ describe("format validation", () => {
  
        })
 
-
-    it("allows work with multiple validations", function() {
-
-        //zipcode regex
-        var pattern = /^[0-9]{8}$/
-         
-        const samples = [
-            "05541030",37130000
-        ]
- 
-        for (const value of samples) {
-            // given
-            const validations = { format: pattern, presence: true }
-            // when
-            const ret = validate(value, validations)
-            // then
-            assert.deepStrictEqual(ret, { value: value, errors: [] })
-        }
- 
-       })
-      
+    
     it('does not allow values that not matches the pattern', () => {
 
          //zipcode regex
          var pattern = /^[0-9]{8}$/
         
          const samples = [
-            "fz055410",true,37130.000,['37130000']
+            "fz055410",true,37130.000,new Date()
          ]
         for (const value of samples) {
             // given

--- a/test/validators/format.js
+++ b/test/validators/format.js
@@ -50,7 +50,7 @@ describe("format validation", () => {
       it("allows RegExp flag pattern", function() {
 
         //zipcode regex
-        var pattern = new RegExp('^[0-9]{8}$')
+        var pattern = new RegExp('^[0-9]{8}$','i')
          
         const samples = [
            "05541030",37130000

--- a/test/validators/format.js
+++ b/test/validators/format.js
@@ -1,0 +1,106 @@
+const assert = require("assert")
+const { validate, errorCodes } = require("../../src/suma")
+const err = errorCodes
+
+describe("format validation", () => {
+    it('does allow empty values', () => {
+
+        //zipcode regex
+        var pattern = /^[0-9]{8}$/
+        
+        const samples = [
+            {},
+            [],
+            '',
+            ' ',
+            null,
+            undefined
+        ]
+        for (const value of samples) {
+            // given
+            const validations = { format: pattern }
+            // when
+            const ret = validate(value, validations)
+            // then
+            assert.deepStrictEqual(ret, { value: value, errors: [] })
+        }
+    })
+
+    it("allows values that matches the pattern", function() {
+
+       //zipcode regex
+       var pattern = /^[0-9]{8}$/
+        
+       const samples = [
+          "05541030"
+       ]
+
+       for (const value of samples) {
+           // given
+           const validations = { format: pattern }
+           // when
+           const ret = validate(value, validations)
+           // then
+           assert.deepStrictEqual(ret, { value: value, errors: [] })
+       }
+
+      })
+
+
+    it("allows work with multiple validations", function() {
+
+        //zipcode regex
+        var pattern = /^[0-9]{8}$/
+         
+        const samples = [
+           "05541030"
+        ]
+ 
+        for (const value of samples) {
+            // given
+            const validations = { format: pattern, presence: true }
+            // when
+            const ret = validate(value, validations)
+            // then
+            assert.deepStrictEqual(ret, { value: value, errors: [] })
+        }
+ 
+       })
+      
+    it('does not allow values that not matches the pattern', () => {
+
+         //zipcode regex
+         var pattern = /^[0-9]{8}$/
+        
+         const samples = [
+            "fz055410"
+         ]
+        for (const value of samples) {
+            // given
+            const validations = { format: pattern  }
+            // when
+            const ret = validate(value, validations)
+            // then
+            assert.deepStrictEqual(ret, { value: value, errors: [{ [err.invalidFormat]: true }] })
+        }
+    })
+
+    it('does not allow non string values', () => {
+
+        //zipcode regex
+        var pattern = /^[0-9]{8}$/
+       
+        const samples = [
+           05541
+        ]
+       for (const value of samples) {
+           // given
+           const validations = { format: pattern  }
+           // when
+           const ret = validate(value, validations)
+           // then
+           assert.deepStrictEqual(ret, { value: value, errors: [{ [err.invalidFormat]: true }] })
+       }
+   })
+    
+})

--- a/test/validators/format.js
+++ b/test/validators/format.js
@@ -7,7 +7,6 @@ describe("format validation", () => {
 
         //zipcode regex
         var pattern = /^[0-9]{8}$/
-        
         const samples = [
             {},
             [],
@@ -26,63 +25,94 @@ describe("format validation", () => {
         }
     })
 
-    it("allows values that matches the pattern", function() {
+    it("allows values that matches the pattern", function () {
 
-       //zipcode regex
-       var pattern = /^[0-9]{8}$/
-        
-       const samples = [
-          "05541030",37130000,['37130000']
-       ]
+        const samples = [
+            [new RegExp('^[0-9]{8}$'), '05541030'],
+            [/^[0-9]{8}$/, 26130014],
+            [/^[0-9]{8}$/, ['37130000']],
+            [/\S+@\S+\.\S+/i, 'sample@email.com'],
+            [/^\(?[\d]{3}\)?[\s-]?[\d]{3}[\s-]?[\d]{4}$/, '573-884-1234'],
+        ]
 
-       for (const value of samples) {
-           // given
-           const validations = { format: pattern }
-           // when
-           const ret = validate(value, validations)
-           // then
-           assert.deepStrictEqual(ret, { value: value, errors: [] })
-       }
+        for (const value of samples) {
+            // given
+            const validations = { format: value[0] }
+            // when
+            const ret = validate(value[1], validations)
+            // then
+            assert.deepStrictEqual(ret, { value: value[1], errors: [] })
+        }
 
-      })
+    })
 
+    it('does not allow values that not matches the pattern', () => {
+       
+        const samples = [
+            [new RegExp('^[0-9]{8}$'), 'f05541030'],
+            [/^[0-9]{8}$/, true],
+            [/^[0-9]{8}$/, new Date()],
+            [/\S+@\S+\.\S+/i, 'sampleemail.com'],
+            [/^\(?[\d]{3}\)?[\s-]?[\d]{3}[\s-]?[\d]{4}$/, '73-884-1234'],
+        ]
 
-      it("allows RegExp flag pattern", function() {
+        for (const value of samples) {
+            // given
+            const validations = { format: value[0] }
+            // when
+            const ret = validate(value[1], validations)
+            // then
+            assert.deepStrictEqual(ret, { value: value[1], errors: [{ [err.invalidFormat]: true }] })
+        }
+
+    })
+
+    it("allows expressions that uses flags pattern", function () {
 
         //zipcode regex
-        var pattern = new RegExp('^[0-9]{8}$','i')
-         
-        const samples = [
-           "05541030",37130000
-        ]
- 
-        for (const value of samples) {
-            // given
-            const validations = { format: pattern }
-            // when
-            const ret = validate(value, validations)
-            // then
-            assert.deepStrictEqual(ret, { value: value, errors: [] })
-        }
- 
-       })
+        var pattern = new RegExp('^[0-9]{8}$', 'i')
 
-    
-    it('does not allow values that not matches the pattern', () => {
+        const value = "05541030"
+        // given
+        const validations = { format: pattern }
+        // when
+        const ret = validate(value, validations)
+        // then
+        assert.deepStrictEqual(ret, { value: value, errors: [] })
 
-         //zipcode regex
-         var pattern = /^[0-9]{8}$/
-        
-         const samples = [
-            "fz055410",true,37130.000,new Date()
-         ]
-        for (const value of samples) {
-            // given
-            const validations = { format: pattern  }
-            // when
-            const ret = validate(value, validations)
-            // then
-            assert.deepStrictEqual(ret, { value: value, errors: [{ [err.invalidFormat]: true }] })
-        }
-    })   
+    })
+
+    it("doesn't allow partial matches", function () {
+
+        //zipcode regex
+        var pattern = new RegExp('\\.png$', 'g')
+
+        const value = "foo.png"
+        // given
+        const validations = { format: pattern }
+        // when
+        const ret = validate(value, validations)
+        // then
+        assert.deepStrictEqual(ret, { value: value, errors: [] })
+
+    })
+
+
+
+    it("allows work with multiple validations", function () {
+
+        //zipcode regex
+        var pattern = /^[0-9]{8}$/
+
+        const value = "05541030"
+        // given
+        const validations = { format: pattern, presence: true }
+        // when
+        const ret = validate(value, validations)
+        // then
+        assert.deepStrictEqual(ret, { value: value, errors: [] })
+
+    })
+
+
 })

--- a/test/validators/format.js
+++ b/test/validators/format.js
@@ -32,7 +32,7 @@ describe("format validation", () => {
        var pattern = /^[0-9]{8}$/
         
        const samples = [
-          "05541030"
+          "05541030",37130000
        ]
 
        for (const value of samples) {
@@ -47,13 +47,34 @@ describe("format validation", () => {
       })
 
 
+      it("allows RegExp flag pattern", function() {
+
+        //zipcode regex
+        var pattern = new RegExp('^[0-9]{8}$')
+         
+        const samples = [
+           "05541030",37130000
+        ]
+ 
+        for (const value of samples) {
+            // given
+            const validations = { format: pattern }
+            // when
+            const ret = validate(value, validations)
+            // then
+            assert.deepStrictEqual(ret, { value: value, errors: [] })
+        }
+ 
+       })
+
+
     it("allows work with multiple validations", function() {
 
         //zipcode regex
         var pattern = /^[0-9]{8}$/
          
         const samples = [
-           "05541030"
+            "05541030",37130000
         ]
  
         for (const value of samples) {
@@ -73,7 +94,7 @@ describe("format validation", () => {
          var pattern = /^[0-9]{8}$/
         
          const samples = [
-            "fz055410"
+            "fz055410",true,37130.000,['37130000']
          ]
         for (const value of samples) {
             // given
@@ -83,24 +104,5 @@ describe("format validation", () => {
             // then
             assert.deepStrictEqual(ret, { value: value, errors: [{ [err.invalidFormat]: true }] })
         }
-    })
-
-    it('does not allow non string values', () => {
-
-        //zipcode regex
-        var pattern = /^[0-9]{8}$/
-       
-        const samples = [
-           05541
-        ]
-       for (const value of samples) {
-           // given
-           const validations = { format: pattern  }
-           // when
-           const ret = validate(value, validations)
-           // then
-           assert.deepStrictEqual(ret, { value: value, errors: [{ [err.invalidFormat]: true }] })
-       }
-   })
-    
+    })   
 })


### PR DESCRIPTION
I created a formatting feature that validates regex so that we can validate regular expressions.

I believe I found a bug in the project in the isEmpty (checker.js line 61) validation, the regular expression is not seen as a string but as an object, however the one that exists for property validation is not working as it should. I will open an issue.